### PR TITLE
tests: run CI on all supported Python versions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,6 +10,10 @@ jobs:
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
     - name: install
       run: python -m pip install -e .
     - name: test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,6 +5,9 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v3
     - name: install

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,6 +11,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: install
-      run: pip install -e .
+      run: python -m pip install -e .
     - name: test
-      run: make test
+      run: python -m unittest discover

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,9 +13,11 @@ home_page = https://github.com/mr-martian/rebabel-format
 
 [options]
 install_requires =
-  tomli >= 1.1.0 ; python_version < "3.11"
+  dataclasses >= 0.4 ; python_version < "3.7"
   importlib_metadata >= 3.6 ; python_version < "3.10"
   importlib_resources >= 1.4 ; python_version < "3.9"
+  tomli >= 1.1.0 ; python_version < "3.11"
+requires_python = ">= 3.6"
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
also add another backport for 3.6 and specify that we're not supporting 3.5