### PR TITLE
Represent features as single strings

### DIFF
--- a/rebabel_format/config.py
+++ b/rebabel_format/config.py
@@ -28,18 +28,6 @@ def get_param(conf, *locs):
 def get_single_param(conf, action, key):
     return get_param(conf, [action, key], key)
 
-def parse_feature(obj):
-    if isinstance(obj, str) and obj.count(':') == 1:
-        return tuple(obj.split(':'))
-    elif isinstance(obj, dict) and 'tier' in obj and 'feature' in obj:
-        return obj['tier'], obj['feature']
-    elif isinstance(obj, dict) and 'feature' in obj:
-        return parse_feature(obj['feature'])
-    elif (isinstance(obj, list) or isinstance(obj, tuple)) and len(obj) == 2:
-        return obj[0], obj[1]
-    else:
-        raise ValueError(f'Invalid feature specifier {obj}.')
-
 def get_user(conf, action):
     user = get_single_param(conf, action, 'username')
     if user is None:
@@ -56,20 +44,10 @@ def parse_mappings(mappings):
     for i, mp in enumerate(mappings, 1):
         infeat = mp.get('in_feature')
         outfeat = mp.get('out_feature')
-        intier = mp.get('in_tier')
-        outtier = mp.get('out_tier')
         intype = mp.get('in_type')
         outtype = mp.get('out_type')
         if infeat and outfeat:
-            if intier:
-                f_in = (intier, infeat)
-            else:
-                f_in = parse_feature(infeat)
-            if outtier:
-                f_out = (outtier, outfeat)
-            else:
-                f_out = parse_feature(outfeat)
-            features.append((f_in, intype, f_out, outtype))
+            features.append((infeat, intype, outfeat, outtype))
         elif intype and outtype:
             type_dict[intype] = outtype
             rev_type_dict[outtype] = intype

--- a/rebabel_format/converters/conllu.py
+++ b/rebabel_format/converters/conllu.py
@@ -24,8 +24,8 @@ class ConnluReader(LineReader):
     Words whose head is `0` will have `UD:head` unset.
 
     The features and miscelaneous columns will be imported as string features
-    in the tiers `UD/FEATS` and `UD/MISC`, respectively.
-    An exception is made for `UD/MISC:SpaceAfter`, which is imported as a boolean
+    in the tiers `UD:FEATS` and `UD:MISC`, respectively.
+    An exception is made for `UD:MISC:SpaceAfter`, which is imported as a boolean
     feature.
 
     - UD-edep

--- a/rebabel_format/converters/elan.py
+++ b/rebabel_format/converters/elan.py
@@ -106,10 +106,10 @@ class EAFReader(XMLReader):
                             if index:
                                 index_val[name] += 1
                                 self.set_feature(
-                                    xmlid, 'alignment', 'index', 'int',
+                                    xmlid, 'alignment:index', 'int',
                                     index_val[name])
                             name = xmlid
-                        self.set_feature(name, 'ELAN', tier_name, 'str', t)
+                        self.set_feature(name, 'ELAN:'+tier_name, 'str', t)
                     self.names[xmlid] = name
                 elif ann.tag == 'ALIGNABLE_ANNOTATION':
                     t = self.annotation_text(ann)
@@ -125,10 +125,10 @@ class EAFReader(XMLReader):
                                 break
                     self.names[i] = i
                     self.set_type(i, tier_name)
-                    self.set_feature(i, 'alignment', 'starttime', 'int', s)
-                    self.set_feature(i, 'alignment', 'endtime', 'int', e)
+                    self.set_feature(i, 'alignment:starttime', 'int', s)
+                    self.set_feature(i, 'alignment:endtime', 'int', e)
                     if t is not None:
-                        self.set_feature(i, 'ELAN', tier_name, 'str', t)
+                        self.set_feature(i, 'ELAN:'+tier_name, 'str', t)
 
 class EAFWriter(Writer):
     identifier = 'elan'

--- a/rebabel_format/converters/elan.py
+++ b/rebabel_format/converters/elan.py
@@ -156,18 +156,17 @@ class EAFWriter(Writer):
                 }
 
     def write(self, fout):
-        feat_ids = {}
+        feat_names = {}
         for name in self.query_order:
             main = ['ELAN:'+name]
             if self.tiers[name].aligned:
                 main += ['alignment:starttime', 'alignment:endtime']
-            mids = self.table.add_features(name, main, error=False)
             feats = []
             for tier in self.tiers.values():
                 if tier.parent == name and tier.relation == 'Symbolic_Association':
                     feats.append('ELAN:'+tier.name)
-            fids = self.table.add_features(name, feats, error=False)
-            feat_ids[name] = dict(zip(main, mids)), list(zip(feats, fids))
+            self.table.add_features(name, main+feats, error=False)
+            feat_names[name] = feats
         parent_annotations = {}
         times = {0}
         ann_count = 0
@@ -177,15 +176,15 @@ class EAFWriter(Writer):
                     if uid in parent_annotations or uid is None:
                         continue
                     feat_values = result_feats[uid]
-                    main, feats = feat_ids[name]
+                    feats = feat_names[name]
                     ann_count += 1
                     ann_id = f'ann{ann_count}'
                     parent_annotations[uid] = ann_id
 
                     ann1 = ET.SubElement(self.tiers[name].node, 'ANNOTATION')
                     if self.tiers[name].aligned:
-                        start = feat_values.get(main.get('alignment:starttime'))
-                        end = feat_values.get(main.get('alignment:endtime'))
+                        start = feat_values.get('alignment:starttime')
+                        end = feat_values.get('alignment:endtime')
                         if start is None:
                             if not end:
                                 start = max(times)
@@ -212,12 +211,11 @@ class EAFWriter(Writer):
                                 if prev[0].attrib['ANNOTATION_REF'] == pref:
                                     ann2.attrib['PREVIOUS_ANNOTATION'] = prev[0].attrib['ANNOTATION_ID']
                     ann3 = ET.SubElement(ann2, 'ANNOTATION_VALUE')
-                    content = feat_values.get(main.get('ELAN:'+name))
+                    content = feat_values.get('ELAN:'+name)
                     if content is not None:
                         ann3.text = str(content)
 
-                    for feat, fid in feats:
-                        value = feat_values.get(fid)
+                    for feat, value in feat_values.items():
                         if value is None:
                             continue
                         feat_name = feat[5:]

--- a/rebabel_format/converters/flextext.py
+++ b/rebabel_format/converters/flextext.py
@@ -21,7 +21,7 @@ class FlextextReader(XMLReader):
     for a given parent node.
 
     Any <item> nodes will be imported as string features. The tier will be
-    `FlexText/[lang]`, the feature will be `[type]`, and the value will be
+    `FlexText:[lang]`, the feature will be `[type]`, and the value will be
     the text content of the XML node.
     '''
     identifier = 'flextext'

--- a/rebabel_format/converters/flextext.py
+++ b/rebabel_format/converters/flextext.py
@@ -161,11 +161,9 @@ class FlextextWriter(Writer):
             'word': 'morphemes',
         }
         tree = ET.Element('document', version='2')
-        feats = {}
         for layer in self.query_order:
             if layer in self.query:
-                feats[layer] = sorted(
-                    self.table.add_tier(layer, 'FlexText').items())
+                self.table.add_tier(layer, 'FlexText')
         uid2elem = {}
         for id_dict, feat_dict in self.table.results():
             elem = None
@@ -182,9 +180,8 @@ class FlextextWriter(Writer):
                     parent = ET.SubElement(elem, group_names[layer])
                 uid2elem[lid] = (elem, parent)
                 unit_feats = feat_dict.get(lid, {})
-                for feat, fid in feats.get(layer, []):
+                for feat, val in unit_feats.items():
                     parts = feat.split(':')
-                    val = unit_feats.get(fid)
                     if val is None or len(parts) != 3:
                         continue
                     i = ET.SubElement(elem, 'item', lang=parts[1], type=parts[2])

--- a/rebabel_format/converters/macula.py
+++ b/rebabel_format/converters/macula.py
@@ -48,11 +48,11 @@ class MaculaNodeReader(XMLReader):
                         self.add_relation(gid, nid)
 
                 if child.text and not child.text.isspace():
-                    self.set_feature(nid, 'macula', 'form', 'str', child.text)
+                    self.set_feature(nid, 'macula:form', 'str', child.text)
 
                 for key, value in child.attrib.items():
                     if key in node_ids:
                         key = 'id'
-                    self.set_feature(nid, 'macula', key, 'str', value)
+                    self.set_feature(nid, 'macula:'+key, 'str', value)
 
         self.finish_block()

--- a/rebabel_format/converters/sfm.py
+++ b/rebabel_format/converters/sfm.py
@@ -43,7 +43,7 @@ class SFMReader(LineReader):
         cmd = line.split()[0]
         if cmd == r'\ref':
             self.set_type('sentence', 'sentence')
-            self.set_feature('sentence', 'SFM', 'reference', 'str',
+            self.set_feature('sentence', 'SFM:reference', 'str',
                              line.split('.')[1])
 
         elif cmd == r'\tx':
@@ -53,22 +53,22 @@ class SFMReader(LineReader):
                 name = ('word', wid)
                 self.set_type(name, 'word')
                 self.set_parent(name, 'sentence')
-                self.set_feature(name, 'SFM', 'form', 'str', word)
-                self.set_feature(name, 'meta', 'index', 'int', wid)
+                self.set_feature(name, 'SFM:form', 'str', word)
+                self.set_feature(name, 'meta:index', 'int', wid)
 
         elif cmd == r'\mb':
             for morph, wid, mid in self.iter_morphs(line):
                 name = ('morph', wid, mid)
                 self.set_type(name, 'morpheme')
                 self.set_parent(name, ('word', wid))
-                self.set_feature(name, 'meta', 'index', 'int', mid)
-                self.set_feature(name, 'SFM', 'form', 'str', morph)
+                self.set_feature(name, 'meta:index', 'int', mid)
+                self.set_feature(name, 'SFM:form', 'str', morph)
 
         elif cmd == r'\gl':
             for morph, wid, mid in self.iter_morphs(line):
                 name = ('morph', wid, mid)
-                self.set_feature(name, 'SFM', 'gls', 'str', morph)
+                self.set_feature(name, 'SFM:gls', 'str', morph)
 
         elif cmd == r'\ft':
-            self.set_feature('sentence', 'SFM', 'translation', 'str',
+            self.set_feature('sentence', 'SFM:translation', 'str',
                              line[3:].strip())

--- a/rebabel_format/converters/textfabric.py
+++ b/rebabel_format/converters/textfabric.py
@@ -9,13 +9,13 @@ class TextFabricReader(Reader):
     name in the `textfabric` tier. The value type is either string or integer
     as specified in the feature file.
 
-    Each unit also has an integer feature named `textfabric-meta:id`, which
+    Each unit also has an integer feature named `textfabric:meta:id`, which
     contains the numeric ID of the unit in Text-Fabric.
 
     Edges and edge features are imported as units of type `[name]-tf-link`,
-    which have reference features `textfabric-meta:parent` and
-    `textfabric-meta:child`, and a string or integer feature
-    `textfabric-meta:value`, if applicable.
+    which have reference features `textfabric:meta:parent` and
+    `textfabric:meta:child`, and a string or integer feature
+    `textfabric:meta:value`, if applicable.
     '''
 
     identifier = 'textfabric'
@@ -124,11 +124,11 @@ class TextFabricReader(Reader):
                 if feature_name == 'otype':
                     for node in nodes:
                         self.set_type(node, value)
-                        self.set_feature(node, 'textfabric-meta', 'id', 'int',
+                        self.set_feature(node, 'textfabric:meta:id', 'int',
                                          node)
                 elif value:
                     for node in nodes:
-                        self.set_feature(node, 'textfabric', feature_name,
+                        self.set_feature(node, 'textfabric:'+feature_name,
                                          'str' if is_str else 'int', value)
             else:
                 if len(pieces) == 1:
@@ -155,10 +155,10 @@ class TextFabricReader(Reader):
                 for f in nfrom:
                     for t in nto:
                         self.set_type((t, f), feature_name + '-tf-link')
-                        self.set_feature((t, f), 'textfabric-meta', 'parent',
+                        self.set_feature((t, f), 'textfabric:meta:parent',
                                          'ref', f)
-                        self.set_feature((t, f), 'textfabric-meta', 'child',
+                        self.set_feature((t, f), 'textfabric:meta:child',
                                          'ref', t)
                         if value:
-                            self.set_feature((t, f), 'textfabric-meta', 'value',
+                            self.set_feature((t, f), 'textfabric:meta:value',
                                              'str' if is_str else 'int', value)

--- a/rebabel_format/parameters.py
+++ b/rebabel_format/parameters.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from rebabel_format.config import get_single_param, parse_feature, parse_mappings
+from rebabel_format.config import get_single_param, parse_mappings
 from dataclasses import dataclass
 from typing import Any
 
@@ -70,12 +70,6 @@ class QueryParameter(Parameter):
             raise ValueError('Query contains no valid nodes.')
         # TODO: check parent etc
         return val
-
-@dataclass
-class FeatureParameter(Parameter):
-    def process(self, name, value):
-        val = super().process(name, value)
-        return parse_feature(val)
 
 @dataclass
 class MappingParameter(Parameter):

--- a/rebabel_format/process.py
+++ b/rebabel_format/process.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 from rebabel_format.db import RBBLFile
-from rebabel_format.config import parse_feature
 from rebabel_format.parameters import Parameter, DBParameter, QueryParameter
 import logging
 
@@ -44,9 +43,8 @@ class Process(metaclass=MetaProcess):
     def run(self):
         pass
 
-    def get_feature(self, unittype, spec):
-        tier, feature = parse_feature(spec)
-        return self.db.get_feature(unittype, tier, feature)
+    def get_feature(self, unittype: str, feature: str):
+        return self.db.get_feature(unittype, feature)
 
     @classmethod
     def help_text_epilog(cls):
@@ -75,7 +73,7 @@ class SearchProcess(Process):
     def get_value(self, result, spec):
         uid = result[spec['unit']]
         utype = self.db.get_unit_type(uid)
-        fid, vtype = self.db.get_feature(utype, spec['tier'], spec['feature'])
+        fid, vtype = self.db.get_feature(utype, spec['feature'])
         return self.db.get_feature_value(uid, fid)
 
     def print_label(self, result, labels):

--- a/rebabel_format/processes/concordance.py
+++ b/rebabel_format/processes/concordance.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 from rebabel_format.process import SearchProcess
-from rebabel_format.parameters import Parameter, FeatureParameter
+from rebabel_format.parameters import Parameter
 
 from functools import lru_cache
 
@@ -14,7 +14,7 @@ class Concordance(SearchProcess):
     width = Parameter(default=2, help='width of concordance window')
     label = Parameter(type=list,
                       help='features of units from the query to label each output line with')
-    print = FeatureParameter(help='feature to display for units in the concordance window')
+    print = Parameter(type=str, help='feature to display for units in the concordance window')
 
     @lru_cache(maxsize=100)
     def get_children(db, uid, child_type):
@@ -22,7 +22,7 @@ class Concordance(SearchProcess):
 
     def get_child_bound(self, uid, child_type, bound, right):
         children = Concordance.get_children(self.db, uid, child_type)
-        fid, ftype = self.db.get_feature(child_type, 'meta', 'index')
+        fid, ftype = self.db.get_feature(child_type, 'meta:index')
         idx = self.db.get_feature_values(children, fid)
         children.sort(key=lambda c: idx.get(c, bound))
         if right:
@@ -48,7 +48,7 @@ class Concordance(SearchProcess):
         if uid is None:
             return None
         utype = self.db.get_unit_type(uid)
-        fid, ftype = self.db.get_feature(utype, 'meta', 'index')
+        fid, ftype = self.db.get_feature(utype, 'meta:index')
         idx = self.db.get_feature_value(uid, fid)
         parent = self.db.get_parent(uid)
         if parent is None:
@@ -73,7 +73,7 @@ class Concordance(SearchProcess):
 
     def print_span(self, span):
         utype = self.db.get_unit_type(span[0])
-        fid, ftype = self.db.get_feature(utype, *self.print)
+        fid, ftype = self.db.get_feature(utype, self.print)
         print(' '.join(str(self.db.get_feature_value(u, fid)) for u in span))
 
     def per_result(self, result):

--- a/rebabel_format/processes/distribution.py
+++ b/rebabel_format/processes/distribution.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 from rebabel_format.process import Process
-from rebabel_format.parameters import Parameter, FeatureParameter, QueryParameter
+from rebabel_format.parameters import Parameter, QueryParameter
 from rebabel_format.query import ResultTable
 from collections import Counter
 
@@ -17,7 +17,7 @@ class Distribution(Process):
     center = Parameter(default='Center', help='the element of the pattern which is the parent of the units being counted')
     child_type = Parameter(type=str, help='the type of the units being counted')
     child_print = Parameter(type=list, help='the features to count')
-    sort = FeatureParameter(default='meta:index', help='the feature to use for sorting')
+    sort = Parameter(default='meta:index', type=str, help='the feature to use for sorting')
     include = Parameter(default=[], type=list, help='features from the pattern to include when counting')
 
     def display_unit(self, features):

--- a/rebabel_format/processes/query.py
+++ b/rebabel_format/processes/query.py
@@ -19,7 +19,6 @@ class Search(Process):
             print('\t'+lab.ljust(self.lab_width+3)+'\t'+v)
 
     def run(self):
-        from rebabel_format.config import parse_feature
         from collections import defaultdict
         from rebabel_format.query import search
         self.print_feats = defaultdict(list)
@@ -31,18 +30,16 @@ class Search(Process):
             typ = item.get('type')
             if typ is None:
                 continue
-            for p in pr:
-                t, f = parse_feature(p)
-                lab = f'{t}:{f}'
-                self.lab_width = max(self.lab_width, len(lab))
+            for feat in pr:
+                self.lab_width = max(self.lab_width, len(feat))
                 got_any = False
                 for single_type in utils.as_list(typ):
-                    fid, _ = self.db.get_feature(single_type, t, f, error=False)
+                    fid, _ = self.db.get_feature(single_type, feat, error=False)
                     if fid is None: continue
-                    self.print_feats[name].append((lab, fid))
+                    self.print_feats[name].append((feat, fid))
                     got_any = True
                 if not got_any:
-                    raise ValueError(f"Could not find print feature '{p}' for unit '{name}'.")
+                    raise ValueError(f"Could not find print feature '{feat}' for unit '{name}'.")
         for n, result in enumerate(search(self.db, self.query), 1):
             print('Result', n)
             for name, uid in sorted(result.items()):

--- a/rebabel_format/query.py
+++ b/rebabel_format/query.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 from rebabel_format.db import RBBLFile, WhereClause
-from rebabel_format.config import parse_feature
 from rebabel_format import utils
 
 from collections import defaultdict
@@ -45,13 +44,13 @@ class UnitQuery:
         self.unittype = unittype
         self.features = []
     def add_feature(self, spec):
-        if 'tier' not in spec or 'feature' not in spec:
+        if 'feature' not in spec:
             raise ValueError(f'Invalid feature specifier {spec}.')
-        feats = self.db.get_feature_multi_type(self.unittype, spec['tier'],
-                                               spec['feature'], error=True)
+        feats = self.db.get_feature_multi_type(self.unittype, spec['feature'],
+                                               error=True)
         ftypes = sorted(set(f[1] for f in feats))
         if len(ftypes) > 1:
-            raise ValueError(f"Feature '{spec['tier']}:{spec['feature']}' has multiple types; found {ftypes}.")
+            raise ValueError(f"Feature '{spec['feature']}' has multiple types; found {ftypes}.")
         ftyp = ftypes[0]
         fid = [f[0] for f in feats]
         if ftyp == 'ref':
@@ -183,13 +182,12 @@ def search(db, query, order=None):
         elif not units[name]:
             return
         if 'order' in pattern:
-            tier, feature = parse_feature(pattern['order'])
-            feats = db.get_feature_multi_type(pattern['type'], tier, feature,
+            feats = db.get_feature_multi_type(pattern['type'], pattern['order'],
                                               error=False)
             if not feats:
-                raise ValueError(f"Cannot find feature '{tier}:{feature}' for ordering unit '{name}'.")
+                raise ValueError(f"Cannot find feature '{pattern['order']}' for ordering unit '{name}'.")
             if len(set(f[1] for f in feats)) > 1:
-                raise ValueError(f"Cannot sort unit '{name}' by feature '{spec['tier']}:{spec['feature']}' because it has multiple types.")
+                raise ValueError(f"Cannot sort unit '{name}' by feature '{pattern['order']}' because it has multiple types.")
             order_by[name] = db.get_feature_values(units[name],
                                                    [f[0] for f in feats])
         if 'parent' in pattern and pattern['parent'] is not None:
@@ -268,11 +266,10 @@ def map_query(query, type_map, feat_map):
 
     def map_feat(oldfeat, oldtypes):
         nonlocal feat_map
-        tier, feat = parse_feature(oldfeat)
         for typ in oldtypes + [None]:
-            if ((tier, feat), typ) in feat_map:
-                return feat_map[((tier, feat), typ)][0]
-        return tier, feat
+            if (oldfeat, typ) in feat_map:
+                return feat_map[(oldfeat, typ)][0]
+        return oldfeat
 
     if not type_map and not feat_map:
         return
@@ -282,11 +279,10 @@ def map_query(query, type_map, feat_map):
         oldtypes = utils.as_list(v['type'])
         v['type'] = [type_map.get(t, t) for t in oldtypes]
         if 'order' in v:
-            t, f = map_feat(v['order'], oldtypes)
-            v['order'] = {'tier': t, 'feature': f}
+            v['order'] = map_feat(v['order'], oldtypes)
         if 'features' in v:
             for dct in v['features']:
-                dct['tier'], dct['feature'] = map_feat(dct, oldtypes)
+                dct['feature'] = map_feat(dct, oldtypes)
 
 class ResultTable:
     def __init__(self, db, query, order=None, type_map=None, feat_map=None):
@@ -348,31 +344,29 @@ class ResultTable:
                 else:
                     feat_types[f] = t[0]
             else:
-                tier, feature = parse_feature(f)
                 if map_features:
                     for (fi, ti), (fo, to) in self.feat_map.items():
-                        if fo != (tier, feature):
+                        if fo != f:
                             continue
                         # types will have already been remapped
                         if ti not in utils.as_list(self.types[node]) + [None]:
                             continue
-                        tier, feature = fi
+                        f = fi
                         break
                 # TODO: If there's multiple types, this should get all
                 # features. We probably want to return a dict from this
                 # function.
-                f = self.db.first_clauses('SELECT id, valuetype FROM tiers',
-                                          WhereClause('tier', tier),
-                                          WhereClause('feature', feature),
-                                          WhereClause('unittype', types))
-                if f is None:
+                fv = self.db.first_clauses('SELECT id, valuetype FROM tiers',
+                                           WhereClause('name', f),
+                                           WhereClause('unittype', types))
+                if fv is None:
                     if error:
-                        raise ValueError(f'Feature {tier}:{feature} does not exist for unit type {types}.')
+                        raise ValueError(f'Feature {f} does not exist for unit type {types}.')
                     else:
                         feats.append(None)
                         continue
-                feats.append(f[0])
-                feat_types[f[0]] = f[1]
+                feats.append(fv[0])
+                feat_types[fv[0]] = fv[1]
         units = list(set(self._node_ids(node)))
         self.db.execute_clauses('SELECT unit, feature, value FROM features',
                                 WhereClause('unit', units),
@@ -385,36 +379,29 @@ class ResultTable:
         return feats
 
     def add_tier(self, node: str, tier: str, prefix=False):
-        tier_list = [tier]
-        if prefix:
-            self.db.execute_clauses('SELECT DISTINCT tier FROM tiers',
-                                    WhereClause('unittype', self.types[node]))
-            tier_list = [t[0] for t in self.db.cur.fetchall()
-                         if t[0].startswith(tier)]
         names = []
         feats = []
         skip = set()
         for (fi, ti), (fo, to) in self.feat_map.items():
             if ti and ti not in self.types[node]:
                 continue
-            if fo[0] == tier or (prefix and fo[0].startswith(tier)):
+            if fo.startswith(tier+':'):
                 f = self.db.first_clauses('SELECT id FROM tiers',
-                                          WhereClause('tier', fi[0]),
-                                          WhereClause('feature', fi[1]),
+                                          WhereClause('name', fi),
                                           WhereClause('unittype', self.types[node]))
                 if f:
                     feats.append(f[0])
                     names.append(fo)
-            if fi[0] == tier or (prefix and fi[0].startswith(tier)):
+            if fi.startswith(tier+':'):
                 skip.add(fi)
-        self.db.execute_clauses('SELECT id, tier, feature FROM tiers',
+        self.db.execute_clauses('SELECT id, name FROM tiers',
                                 WhereClause('unittype', self.types[node]),
-                                WhereClause('tier', tier_list))
-        for i, t, f in self.db.cur.fetchall():
-            if (t, f) in skip:
+                                WhereClause('name', tier+':%', operator='LIKE'))
+        for i, f in self.db.cur.fetchall():
+            if f in skip:
                 continue
             feats.append(i)
-            names.append((t, f))
+            names.append(f)
         ids = self.add_features(node, feats, map_features=False)
         return dict(zip(names, ids))
 

--- a/rebabel_format/query.py
+++ b/rebabel_format/query.py
@@ -354,9 +354,6 @@ class ResultTable:
                             continue
                         f = fi
                         break
-                # TODO: If there's multiple types, this should get all
-                # features. We probably want to return a dict from this
-                # function.
                 self.db.execute_clauses('SELECT id, valuetype FROM tiers',
                                         WhereClause('name', f),
                                         WhereClause('unittype', types))

--- a/rebabel_format/schema.sql
+++ b/rebabel_format/schema.sql
@@ -16,8 +16,7 @@ CREATE TABLE units(
 
 CREATE TABLE tiers(
        id INTEGER PRIMARY KEY,
-       tier TEXT,
-       feature TEXT,
+       name TEXT,
        unittype TEXT,
        valuetype TEXT,
        CHECK(valuetype = 'int' OR valuetype = 'bool' OR

--- a/rebabel_format/test/__init__.py
+++ b/rebabel_format/test/__init__.py
@@ -39,7 +39,7 @@ class StaticTests(unittest.TestCase):
                 text = stream.getvalue()
             with open(fname) as fin:
                 expected = fin.read()
-                self.assertEqual(expected.strip(), text.strip())
+                self.assertEqual(expected.strip()+'\n', text.strip()+'\n')
 
     def single_test(self, name):
         with self.subTest(name):

--- a/rebabel_format/test/static/basic_conllu.01.inspect.txt
+++ b/rebabel_format/test/static/basic_conllu.01.inspect.txt
@@ -6,6 +6,12 @@ sentence
 
 word
 	UD
+		FEATS
+			Definiteness: str
+			Number: str
+			Person: str
+		MISC
+			SpaceAfter: bool
 		deprel: str
 		form: str
 		head: ref
@@ -14,11 +20,5 @@ word
 		null: bool
 		upos: str
 		xpos: str
-	UD/FEATS
-		Definiteness: str
-		Number: str
-		Person: str
-	UD/MISC
-		SpaceAfter: bool
 	meta
 		index: int

--- a/rebabel_format/test/static/basic_conllu.toml
+++ b/rebabel_format/test/static/basic_conllu.toml
@@ -7,7 +7,7 @@ schema = true
 
 [query.W]
 type = 'word'
-features = [{tier = 'UD/FEATS', feature = 'Number', value = 'Sing'}]
+features = [{feature = 'UD:FEATS:Number', value = 'Sing'}]
 print = ['UD:id', 'UD:lemma']
 order = 'UD:lemma'
 
@@ -16,32 +16,30 @@ sequence = ['rule1']
 
 [transform.rule1.query.V]
 type = 'word'
-features = [{tier = 'UD', feature = 'upos', value = 'VERB'}]
+features = [{feature = 'UD:upos', value = 'VERB'}]
 
 [[transform.rule1.commands]]
 type = 'set_feature'
 target = 'V'
-tier = 'UD'
-feature = 'lemma'
+feature = 'UD:lemma'
 value = 'gargle'
 
 [[transform.rule1.commands]]
 type = 'set_feature'
 target = 'V'
-tier = 'UD'
-feature = 'xpos'
+feature = 'UD:xpos'
 value = 'ninja'
 
 [export]
 mode = 'conllu'
 
 [concordance]
-label = [{unit = 'S', tier = 'UD', feature = 'sent_id'}]
+label = [{unit = 'S', feature = 'UD:sent_id'}]
 print = 'UD:upos'
 
 [concordance.query.Center]
 type = 'word'
-features = [{tier = 'UD', feature = 'lemma', value = '.'}]
+features = [{feature = 'UD:lemma', value = '.'}]
 parent = 'S'
 
 [concordance.query.S]

--- a/rebabel_format/test/static/conllu2flextext.toml
+++ b/rebabel_format/test/static/conllu2flextext.toml
@@ -13,8 +13,8 @@ out_type = 'phrase'
 
 [[export.mappings]]
 in_feature = 'UD:lemma'
-out_feature = 'FlexText/en:lem'
+out_feature = 'FlexText:en:lem'
 
 [[export.mappings]]
 in_feature = 'UD:sent_id'
-out_feature = 'FlexText/en:sid'
+out_feature = 'FlexText:en:sid'

--- a/rebabel_format/test/static/multi_node.toml
+++ b/rebabel_format/test/static/multi_node.toml
@@ -11,4 +11,4 @@ type = ['word', 'token']
 print = ['UD:lemma']
 parent = 'S'
 multiple = true
-features = [{tier = 'UD/FEATS', feature = 'Number', value = 'Sing'}]
+features = [{feature = 'UD:FEATS:Number', value = 'Sing'}]

--- a/rebabel_format/transform.py
+++ b/rebabel_format/transform.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 from rebabel_format.db import RBBLFile
-from rebabel_format.config import parse_feature
 from rebabel_format.query import search
 
 from collections import defaultdict
@@ -11,12 +10,12 @@ def transform(db, trans, username='user', confidence=1):
     for match in search(db, trans['query']):
         for cmd in trans['commands']:
             if cmd['type'] == 'set_feature':
-                db.set_feature(match[cmd['target']], cmd['tier'],
-                               cmd['feature'], cmd['value'], user=username,
+                db.set_feature(match[cmd['target']], cmd['feature'],
+                               cmd['value'], user=username,
                                confidence=confidence)
             elif cmd['type'] == 'create_unit':
                 uid = db.create_unit(cmd['unit_type'], user=username)
                 match[cmd.get('unit_name')] = uid
             elif cmd['type'] == 'create_feature':
-                db.create_feature(cmd['unit_type'], cmd['tier'], cmd['feature'],
+                db.create_feature(cmd['unit_type'], cmd['feature'],
                                   cmd['value_type'])

--- a/rebabel_format/writer.py
+++ b/rebabel_format/writer.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 from rebabel_format.db import RBBLFile
-from rebabel_format.config import parse_feature
 from rebabel_format.parameters import Parameter
 
 ALL_WRITERS = {}


### PR DESCRIPTION
As suggested in #13, explore representing feature names as single strings with `:` as a separator of hierarchical components rather than a bipartite `tier:feature` that gets parsed into a more complex structure.

Additionally, `ResultTable` now returns feature values by name rather than by ID, which is preferable for most uses.